### PR TITLE
Step3-1 [manager/user]deviseのメール認証機能の実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,5 @@ yarn-debug.log*
 # Ignore yard document
 .yardoc/
 doc/
+
+/.env

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -89,6 +89,10 @@ Style/RedundantSelf:
 Style/RegexpLiteral:
   AllowInnerSlashes: true
 
+# クラスやモジュールを書くまえにドキュメントを書くことを無効化
+Style/Documentation:
+  Enabled: false
+
 # 引数のインデントスタイルを指定
 Layout/ArgumentAlignment:
   EnforcedStyle: with_fixed_indentation

--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,9 @@ gem 'bootsnap', require: false
 # Use Sass to process CSS
 gem 'sassc-rails'
 
+# 環境変数を管理する
+gem 'dotenv-rails'
+
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,6 +122,10 @@ GEM
     diff-lcs (1.5.0)
     digest (3.1.0)
     docile (1.4.0)
+    dotenv (2.7.6)
+    dotenv-rails (2.7.6)
+      dotenv (= 2.7.6)
+      railties (>= 3.2)
     erubi (1.10.0)
     factory_bot (6.2.0)
       activesupport (>= 5.0.0)
@@ -376,6 +380,7 @@ DEPENDENCIES
   devise
   devise-i18n
   devise-i18n-views
+  dotenv-rails
   factory_bot_rails
   jbuilder
   jsbundling-rails

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@
 ```
 docker-compose build
 ```
+- アセットのセッティング
+```
+docker-compose run --rm app rails assets:precompile
+```
 - コンテナ起動
 ```
 docker-compose up

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ApplicationController < ActionController::Base # rubocop:disable Style/Documentation
+class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   def configure_permitted_parameters

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,10 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit :sign_up, keys: [:email]
+    devise_parameter_sanitizer.permit :sign_in, keys: [:email]
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class ApplicationController < ActionController::Base
+class ApplicationController < ActionController::Base # rubocop:disable Style/Documentation
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   def configure_permitted_parameters

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 class ApplicationMailer < ActionMailer::Base
-  default from: ENV["SEND_MAIL"]
+  default from: ENV['SEND_MAIL']
   layout 'mailer'
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
+  default from: ENV["SEND_MAIL"]
   layout 'mailer'
 end

--- a/app/models/manager.rb
+++ b/app/models/manager.rb
@@ -4,5 +4,5 @@ class Manager < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-    :recoverable, :rememberable, :validatable
+    :recoverable, :rememberable, :validatable, :confirmable
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,5 +4,5 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-    :recoverable, :rememberable, :validatable
+    :recoverable, :rememberable, :validatable, :confirmable
 end

--- a/app/views/managers/mailer/confirmation_instructions.html.erb
+++ b/app/views/managers/mailer/confirmation_instructions.html.erb
@@ -2,4 +2,4 @@
 
 <p>You can confirm your account email through the link below:</p>
 
-<p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>
+<p><%= link_to 'Confirm my account', manager_confirmation_url(controller: 'devise/confirmations', action: 'create', confirmation_token: @token) %></p>

--- a/app/views/managers/shared/_links.html.erb
+++ b/app/views/managers/shared/_links.html.erb
@@ -11,7 +11,7 @@
 <% end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-  <%= link_to t('.didn_t_receive_confirmation_instructions'), new_confirmation_path(resource_name) %><br />
+  <%= link_to t('.didn_t_receive_confirmation_instructions'), new_manager_confirmation_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>

--- a/app/views/users/mailer/confirmation_instructions.html.erb
+++ b/app/views/users/mailer/confirmation_instructions.html.erb
@@ -2,4 +2,4 @@
 
 <p>You can confirm your account email through the link below:</p>
 
-<p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>
+<p><%= link_to 'Confirm my account', user_confirmation_url(controller: 'devise/confirmations', action: 'create', confirmation_token: @token) %></p>

--- a/app/views/users/shared/_links.html.erb
+++ b/app/views/users/shared/_links.html.erb
@@ -11,7 +11,7 @@
 <% end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-  <%= link_to t('.didn_t_receive_confirmation_instructions'), new_confirmation_path(resource_name) %><br />
+  <%= link_to t('.didn_t_receive_confirmation_instructions'), new_user_confirmation_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -45,18 +45,19 @@ Rails.application.configure do
   Rails.application.routes.default_url_options[:host] = 'localhost:3000'
   config.action_mailer.perform_caching = false
   config.action_mailer.default_url_options = { host: 'localhost:3000' }
-  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.delivery_method = :letter_opener
   config.action_mailer.perform_deliveries = true
 
-  config.action_mailer.smtp_settings = {
-    port:                 587,
-    address:              'smtp.gmail.com',
-    domain:               'gmail.com',
-    user_name:            ENV['SEND_MAIL'],
-    password:             ENV['SEND_MAIL_PASSWORD'],
-    authentication:       'plain',
-    enable_starttls_auto: true
-  }
+  # 開発環境でメールを送信するための設定。今回はletter_openerを使うため一旦コメントアウト。
+  # config.action_mailer.smtp_settings = {
+  #   port:                 587,
+  #   address:              'smtp.gmail.com',
+  #   domain:               'gmail.com',
+  #   user_name:            ENV['SEND_MAIL'],
+  #   password:             ENV['SEND_MAIL_PASSWORD'],
+  #   authentication:       'plain',
+  #   enable_starttls_auto: true
+  # }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -39,12 +39,24 @@ Rails.application.configure do
   config.active_storage.service = :local
 
   # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
 
   ActionMailer::Base.delivery_method = :letter_opener_web
   Rails.application.routes.default_url_options[:host] = 'localhost:3000'
   config.action_mailer.perform_caching = false
   config.action_mailer.default_url_options = { host: 'localhost:3000' }
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.perform_deliveries = true
+
+  config.action_mailer.smtp_settings = {
+    port:                 587,
+    address:              'smtp.gmail.com',
+    domain:               'gmail.com',
+    user_name:            ENV['SEND_MAIL'],
+    password:             ENV['SEND_MAIL_PASSWORD'],
+    authentication:       'plain',
+    enable_starttls_auto: true
+  }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -44,6 +44,8 @@ Rails.application.configure do
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
+  # テスト環境のデフォルトオプション
+  config.action_mailer.default_url_options = { :host => 'localhost:3000' }
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -45,7 +45,7 @@ Rails.application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
   # テスト環境のデフォルトオプション
-  config.action_mailer.default_url_options = { :host => 'localhost:3000' }
+  config.action_mailer.default_url_options = { host: 'localhost:3000' }
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr

--- a/db/migrate/20220228224433_devise_create_users.rb
+++ b/db/migrate/20220228224433_devise_create_users.rb
@@ -22,10 +22,10 @@ class DeviseCreateUsers < ActiveRecord::Migration[7.0]
       # t.string   :last_sign_in_ip
 
       ## Confirmable
-      # t.string   :confirmation_token
-      # t.datetime :confirmed_at
-      # t.datetime :confirmation_sent_at
-      # t.string   :unconfirmed_email # Only if using reconfirmable
+      t.string   :confirmation_token
+      t.datetime :confirmed_at
+      t.datetime :confirmation_sent_at
+      t.string   :unconfirmed_email # Only if using reconfirmable
 
       ## Lockable
       # t.integer  :failed_attempts, default: 0, null: false # Only if lock strategy is :failed_attempts

--- a/db/migrate/20220228224503_devise_create_managers.rb
+++ b/db/migrate/20220228224503_devise_create_managers.rb
@@ -22,10 +22,10 @@ class DeviseCreateManagers < ActiveRecord::Migration[7.0]
       # t.string   :last_sign_in_ip
 
       ## Confirmable
-      # t.string   :confirmation_token
-      # t.datetime :confirmed_at
-      # t.datetime :confirmation_sent_at
-      # t.string   :unconfirmed_email # Only if using reconfirmable
+      t.string   :confirmation_token
+      t.datetime :confirmed_at
+      t.datetime :confirmation_sent_at
+      t.string   :unconfirmed_email # Only if using reconfirmable
 
       ## Lockable
       # t.integer  :failed_attempts, default: 0, null: false # Only if lock strategy is :failed_attempts

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -29,6 +29,10 @@ ActiveRecord::Schema[7.0].define(version: 2022_02_28_224503) do
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string "unconfirmed_email"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_managers_on_email", unique: true
@@ -41,6 +45,10 @@ ActiveRecord::Schema[7.0].define(version: 2022_02_28_224503) do
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string "unconfirmed_email"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_users_on_email", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,40 +10,41 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 20_220_228_224_503) do
-  create_table 'admins', charset: 'utf8mb4', collation: 'utf8mb4_0900_ai_ci', force: :cascade do |t|
-    t.string 'email', default: '', null: false
-    t.string 'encrypted_password', default: '', null: false
-    t.string 'reset_password_token'
-    t.datetime 'reset_password_sent_at'
-    t.datetime 'remember_created_at'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['email'], name: 'index_admins_on_email', unique: true
-    t.index ['reset_password_token'], name: 'index_admins_on_reset_password_token', unique: true
+ActiveRecord::Schema[7.0].define(version: 2022_02_28_224503) do
+  create_table "admins", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_admins_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_admins_on_reset_password_token", unique: true
   end
 
-  create_table 'managers', charset: 'utf8mb4', collation: 'utf8mb4_0900_ai_ci', force: :cascade do |t|
-    t.string 'email', default: '', null: false
-    t.string 'encrypted_password', default: '', null: false
-    t.string 'reset_password_token'
-    t.datetime 'reset_password_sent_at'
-    t.datetime 'remember_created_at'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['email'], name: 'index_managers_on_email', unique: true
-    t.index ['reset_password_token'], name: 'index_managers_on_reset_password_token', unique: true
+  create_table "managers", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_managers_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_managers_on_reset_password_token", unique: true
   end
 
-  create_table 'users', charset: 'utf8mb4', collation: 'utf8mb4_0900_ai_ci', force: :cascade do |t|
-    t.string 'email', default: '', null: false
-    t.string 'encrypted_password', default: '', null: false
-    t.string 'reset_password_token'
-    t.datetime 'reset_password_sent_at'
-    t.datetime 'remember_created_at'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['email'], name: 'index_users_on_email', unique: true
-    t.index ['reset_password_token'], name: 'index_users_on_reset_password_token', unique: true
+  create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
+
 end

--- a/spec/factories/managers.rb
+++ b/spec/factories/managers.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :manager do
+    sequence(:email) { |n| "manager#{n}@example.com" }
+    password { 'password' }
+    password_confirmation { 'password' }
+    confirmed_at { Date.today }
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :user do
+    sequence(:email) { |n| "user#{n}@example.com" }
+    password { 'password' }
+    password_confirmation { 'password' }
+    confirmed_at { Date.today }
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -82,4 +82,9 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
   config.include FactoryBot::Syntax::Methods
+
+  # deviseのヘルパーを使えるようにする。
+  config.include Devise::Test::IntegrationHelpers, type: :request
+  config.include Devise::Test::ControllerHelpers, type: :controller
+  config.include Devise::Test::ControllerHelpers, type: :view
 end

--- a/spec/requests/managers/registration_spec.rb
+++ b/spec/requests/managers/registration_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe "マネージャー登録から認証メールの送信テスト", type: :request do
+  let(:manager) { create(:manager) }
+  let(:manager_params) { attributes_for(:manager) }
+  let(:invalid_manager_params) { attributes_for(:manager, email: "") }
+
+  describe 'マネージャー登録から認証メールの送信テスト' do
+    before do
+      ActionMailer::Base.deliveries.clear
+    end
+    context 'マネージャー登録のパラメータが全て揃っている場合' do
+      it 'リクエストが成功すること' do
+        post manager_registration_path, params: { manager: manager_params }
+        expect(response.status).to eq 302
+      end
+
+      it '認証メールが送信されること' do
+        post manager_registration_path, params: { manager: manager_params }
+        expect(ActionMailer::Base.deliveries.size).to eq 1
+      end
+
+      it 'createが成功すること' do
+        expect do
+          post manager_registration_path, params: { manager: manager_params }
+        end.to change(Manager, :count).by 1
+      end
+
+      it 'リダイレクトされること' do
+        post manager_registration_path, params: { manager: manager_params }
+        expect(response).to redirect_to root_url
+      end
+    end
+
+    context 'マネージャー登録のパラメータが不正な場合' do
+      it '登録はされないがリクエスト自体はエラーにならないこと' do
+        post manager_registration_path, params: { manager: invalid_manager_params }
+        expect(response.status).to eq 200
+      end
+
+      it '認証メールが送信されないこと' do
+        post manager_registration_path, params: { manager: invalid_manager_params }
+        expect(ActionMailer::Base.deliveries.size).to eq 0
+      end
+
+      it '登録が失敗すること' do
+        expect do
+          post manager_registration_path, params: { manager: invalid_manager_params }
+        end.to_not change(Manager, :count)
+      end
+    end
+  end
+end

--- a/spec/requests/managers/registration_spec.rb
+++ b/spec/requests/managers/registration_spec.rb
@@ -1,14 +1,15 @@
 require 'rails_helper'
 
-RSpec.describe "マネージャー登録から認証メールの送信テスト", type: :request do
+RSpec.describe 'マネージャー登録から認証メールの送信テスト', type: :request do
   let(:manager) { create(:manager) }
   let(:manager_params) { attributes_for(:manager) }
-  let(:invalid_manager_params) { attributes_for(:manager, email: "") }
+  let(:invalid_manager_params) { attributes_for(:manager, email: '') }
 
   describe 'マネージャー登録から認証メールの送信テスト' do
-    before do
+    before(:each) do
       ActionMailer::Base.deliveries.clear
     end
+
     context 'マネージャー登録のパラメータが全て揃っている場合' do
       it 'リクエストが成功すること' do
         post manager_registration_path, params: { manager: manager_params }
@@ -21,9 +22,9 @@ RSpec.describe "マネージャー登録から認証メールの送信テスト"
       end
 
       it 'createが成功すること' do
-        expect do
+        expect {
           post manager_registration_path, params: { manager: manager_params }
-        end.to change(Manager, :count).by 1
+        }.to change(Manager, :count).by 1
       end
 
       it 'リダイレクトされること' do
@@ -44,9 +45,9 @@ RSpec.describe "マネージャー登録から認証メールの送信テスト"
       end
 
       it '登録が失敗すること' do
-        expect do
+        expect {
           post manager_registration_path, params: { manager: invalid_manager_params }
-        end.to_not change(Manager, :count)
+        }.not_to change(Manager, :count)
       end
     end
   end

--- a/spec/requests/users/registration_spec.rb
+++ b/spec/requests/users/registration_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe "ユーザー登録から認証メールの送信テスト", type: :request do
+  let(:user) { create(:user) }
+  let(:user_params) { attributes_for(:user) }
+  let(:invalid_user_params) { attributes_for(:user, email: "") }
+
+  describe 'ユーザー登録から認証メールの送信テスト' do
+    before do
+      ActionMailer::Base.deliveries.clear
+    end
+    context 'ユーザー登録のパラメータが全て揃っている場合' do
+      it 'リクエストが成功すること' do
+        post user_registration_path, params: { user: user_params }
+        expect(response.status).to eq 302
+      end
+
+      it '認証メールが送信されること' do
+        post user_registration_path, params: { user: user_params }
+        expect(ActionMailer::Base.deliveries.size).to eq 1
+      end
+
+      it 'createが成功すること' do
+        expect do
+          post user_registration_path, params: { user: user_params }
+        end.to change(User, :count).by 1
+      end
+
+      it 'リダイレクトされること' do
+        post user_registration_path, params: { user: user_params }
+        expect(response).to redirect_to root_url
+      end
+    end
+
+    context 'ユーザー登録のパラメータが不正な場合' do
+      it '登録はされないがリクエスト自体はエラーにならないこと' do
+        post user_registration_path, params: { user: invalid_user_params }
+        expect(response.status).to eq 200
+      end
+
+      it '認証メールが送信されないこと' do
+        post user_registration_path, params: { user: invalid_user_params }
+        expect(ActionMailer::Base.deliveries.size).to eq 0
+      end
+
+      it '登録が失敗すること' do
+        expect do
+          post user_registration_path, params: { user: invalid_user_params }
+        end.to_not change(User, :count)
+      end
+    end
+  end
+end

--- a/spec/requests/users/registration_spec.rb
+++ b/spec/requests/users/registration_spec.rb
@@ -1,14 +1,15 @@
 require 'rails_helper'
 
-RSpec.describe "ユーザー登録から認証メールの送信テスト", type: :request do
+RSpec.describe 'ユーザー登録から認証メールの送信テスト', type: :request do
   let(:user) { create(:user) }
   let(:user_params) { attributes_for(:user) }
-  let(:invalid_user_params) { attributes_for(:user, email: "") }
+  let(:invalid_user_params) { attributes_for(:user, email: '') }
 
   describe 'ユーザー登録から認証メールの送信テスト' do
-    before do
+    before(:each) do
       ActionMailer::Base.deliveries.clear
     end
+
     context 'ユーザー登録のパラメータが全て揃っている場合' do
       it 'リクエストが成功すること' do
         post user_registration_path, params: { user: user_params }
@@ -21,9 +22,9 @@ RSpec.describe "ユーザー登録から認証メールの送信テスト", type
       end
 
       it 'createが成功すること' do
-        expect do
+        expect {
           post user_registration_path, params: { user: user_params }
-        end.to change(User, :count).by 1
+        }.to change(User, :count).by 1
       end
 
       it 'リダイレクトされること' do
@@ -44,9 +45,9 @@ RSpec.describe "ユーザー登録から認証メールの送信テスト", type
       end
 
       it '登録が失敗すること' do
-        expect do
+        expect {
           post user_registration_path, params: { user: invalid_user_params }
-        end.to_not change(User, :count)
+        }.not_to change(User, :count)
       end
     end
   end

--- a/spec/system/managers/session_spec.rb
+++ b/spec/system/managers/session_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe 'ManagerSessions', type: :system do
+
+  context 'マネージャー登録ができることを確認' do
+
+    it 'マネージャー登録ができることを確認' do
+      visit new_manager_registration_path
+      fill_in 'manager[email]', with: 'manager@example.com'
+      fill_in 'manager[password]', with: 'password'
+      fill_in 'manager[password_confirmation]', with: 'password'
+      click_button 'アカウント登録'
+      expect(page).to have_content 'ログイン'
+    end
+  end
+
+  context 'ログインできることを確認' do
+    let!(:manager) { FactoryBot.create(:manager, password: 'password') }
+
+    it 'ログインできることを確認' do
+      visit new_manager_session_path
+      fill_in 'manager[email]', with: manager.email
+      fill_in 'manager[password]', with: manager.password
+      click_button 'ログイン'
+      expect(page).to have_content 'ログアウト'
+    end
+  end
+end

--- a/spec/system/managers/session_spec.rb
+++ b/spec/system/managers/session_spec.rb
@@ -1,9 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'ManagerSessions', type: :system do
-
   context 'マネージャー登録ができることを確認' do
-
     it 'マネージャー登録ができることを確認' do
       visit new_manager_registration_path
       fill_in 'manager[email]', with: 'manager@example.com'

--- a/spec/system/users/session_spec.rb
+++ b/spec/system/users/session_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe 'UserSessions', type: :system do
+
+  context 'ユーザー登録ができることを確認' do
+
+    it 'ユーザー登録ができることを確認' do
+      visit new_user_registration_path
+      fill_in 'user[email]', with: 'user@example.com'
+      fill_in 'user[password]', with: 'password'
+      fill_in 'user[password_confirmation]', with: 'password'
+      click_button 'アカウント登録'
+      expect(page).to have_content 'ログイン'
+    end
+  end
+
+  context 'ログインできることを確認' do
+    let!(:user) { FactoryBot.create(:user, password: 'password') }
+
+    it 'ログインできることを確認' do
+      visit new_user_session_path
+      fill_in 'user[email]', with: user.email
+      fill_in 'user[password]', with: user.password
+      click_button 'ログイン'
+      expect(page).to have_content 'ログアウト'
+    end
+  end
+end

--- a/spec/system/users/session_spec.rb
+++ b/spec/system/users/session_spec.rb
@@ -1,9 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'UserSessions', type: :system do
-
   context 'ユーザー登録ができることを確認' do
-
     it 'ユーザー登録ができることを確認' do
       visit new_user_registration_path
       fill_in 'user[email]', with: 'user@example.com'


### PR DESCRIPTION
### やったこと
- メール認証をおこなう為 devise に Confirmable 機能を追加。
- SMTPによるメール送信機能を追加。
- メール送信用アドレスを保護する為 `gem 'dotenv-rails'` を追加し環境変数を設定する。
- user と manager 双方が作成でき、メール認証後にログインできるように修正。
- パスワードの再設定ができるように修正。
- rubocop ファイルに Style/Documentation を書かなくてもいいように追記。
- メール送信を letter_open を使うように修正。
- ユーザーとマネージャーの登録とログインに対してのシステムスペックを追加。
- ユーザーとマネージャーの登録と認証メール送信に対してのリクエストスペックを追加。

### やらなかったこと
- manager でログアウト後にログインしましたと間違ったメッセージが出るようですが、一旦タスク外として修正していません。

### 確認したこと(手動テスト)
- [x] 新規ユーザーとマネージャーが作成できること。
- [x] ユーザーとマネージャーを作成後認証メールが届くこと。
- [x] 認証メールのステップを踏まないとログインできないこと。
- [x] 認証メール確認後にログインできること。
- [x] パスワードの変更ができること。
- [x] 変更後のパスワードでログインできること。
- [x] letter_open で送信されたメールが確認できること。

### 手動で確認した際の画像
- 登録したメールアドレスに送られてきた認証メール画像。
<img width="1080" alt="スクリーンショット 2022-03-26 午後9 19 08" src="https://user-images.githubusercontent.com/36902599/160237799-c075544a-7a74-4c15-b94a-9c0e603ab159.png">

- パスワード再設定用に送られてきたメール画像。
<img width="1059" alt="スクリーンショット 2022-03-26 午後9 43 16" src="https://user-images.githubusercontent.com/36902599/160237864-b3880be1-5550-495d-a211-8f29f52640e5.png">

- letter_open で送信された認証メールの画像。
<img width="1205" alt="スクリーンショット 2022-03-27 午後0 50 35" src="https://user-images.githubusercontent.com/36902599/160267952-670471bb-a101-489e-960e-a9e1de51953e.png">

### その他
特になし。

