### PR TITLE
Step3-3[manager]managerのアカウント編集機能の実装

### DIFF
--- a/app/controllers/managers/account_controller.rb
+++ b/app/controllers/managers/account_controller.rb
@@ -3,7 +3,6 @@
 module Managers
   # 管理者のアカウント
   class AccountController < Managers::Base
-
     def show; end
 
     def edit; end

--- a/app/controllers/managers/account_controller.rb
+++ b/app/controllers/managers/account_controller.rb
@@ -5,18 +5,13 @@ module Managers
   class AccountController < Managers::Base
     before_action :set_manager, only: %i[show edit update]
 
-    def show
+    def show; end
 
-    end
-
-    def edit
-
-
-    end
+    def edit; end
 
     def update
       if @manager.update(manager_params)
-        sign_in(@manager, :bypass=>true)
+        sign_in(@manager, bypass: true)
         redirect_to managers_show_path
       else
         render :edit
@@ -29,8 +24,8 @@ module Managers
 
     private
 
-      def set_manager
-        @manager = current_manager
-      end
+    def set_manager
+      @manager = current_manager
+    end
   end
 end

--- a/app/controllers/managers/account_controller.rb
+++ b/app/controllers/managers/account_controller.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Managers
+  # 管理者のアカウント
+  class AccountController < Managers::Base
+    before_action :set_manager, only: %i[show edit update]
+
+    def show
+
+    end
+
+    def edit
+
+
+    end
+
+    def update
+      if @manager.update(manager_params)
+        sign_in(@manager, :bypass=>true)
+        redirect_to managers_show_path
+      else
+        render :edit
+      end
+    end
+
+    def manager_params
+      params.require(:manager).permit(:email, :password, :password_confirmation)
+    end
+
+    private
+
+      def set_manager
+        @manager = current_manager
+      end
+  end
+end

--- a/app/controllers/managers/account_controller.rb
+++ b/app/controllers/managers/account_controller.rb
@@ -3,29 +3,22 @@
 module Managers
   # 管理者のアカウント
   class AccountController < Managers::Base
-    before_action :set_manager, only: %i[show edit update]
 
     def show; end
 
     def edit; end
 
     def update
-      if @manager.update(manager_params)
-        sign_in(@manager, bypass: true)
+      if current_manager.update(manager_params)
+        sign_in(current_manager, bypass: true)
         redirect_to managers_show_path
       else
-        render :edit
+        render :edit, status: :unprocessable_entity
       end
     end
 
     def manager_params
       params.require(:manager).permit(:email, :password, :password_confirmation)
-    end
-
-    private
-
-    def set_manager
-      @manager = current_manager
     end
   end
 end

--- a/app/views/managers/account/_form.html.erb
+++ b/app/views/managers/account/_form.html.erb
@@ -1,0 +1,16 @@
+<%= form_with(model: manager, url: managers_update_path, local: true, method: :patch) do |form| %>
+  <%= render "managers/shared/error_messages", resource: manager %>
+  <div class="mb-6 pt-3 rounded bg-gray-200">
+    <%= form.label :email, class: "text-gray-700 text-sm font-bold mb-2 ml-3" %>
+    <%= form.email_field :email, autofocus: true, autocomplete: "email", class: "bg-gray-200 rounded w-full text-gray-700 focus:outline-none border-b-4 border-gray-300 focus:border-purple-600 transition duration-500 px-3 pb-3" %>
+  </div>
+  <div class="mb-6 pt-3 rounded bg-gray-200">
+    <%= form.label :password, class: "text-gray-700 text-sm font-bold mb-2 ml-3" %>
+    <%= form.password_field :password, autocomplete: "current-password", class: "bg-gray-200 rounded w-full text-gray-700 focus:outline-none border-b-4 border-gray-300 focus:border-purple-600 transition duration-500 px-3 pb-3" %>
+  </div>
+  <div class="mb-6 pt-3 rounded bg-gray-200">
+    <%= form.label :password_confirmation, class: "text-gray-700 text-sm font-bold mb-2 ml-3" %>
+    <%= form.password_field :password_confirmation, autocomplete: "current-password", class: "bg-gray-200 rounded w-full text-gray-700 focus:outline-none border-b-4 border-gray-300 focus:border-purple-600 transition duration-500 px-3 pb-3" %>
+  </div>
+  <%= form.submit class: "bg-blue-600 px-5 py-3 w-full text-center md:w-auto rounded-lg text-white text-xs tracking-wider font-semibold hover:bg-blue-800" %>
+<% end %>

--- a/app/views/managers/account/edit.html.erb
+++ b/app/views/managers/account/edit.html.erb
@@ -1,0 +1,25 @@
+<main class="container mx-w-6xl mx-auto py-4">
+    <div class="flex flex-col space-y-8">
+        <div class="grid grid-cols-1 md:grid-cols-4 xl:grid-cols-5 px-4 xl:p-0 gap-y-4 md:gap-6">
+            <div class="md:col-span-2 xl:col-span-3 bg-white p-6 rounded-2xl border border-gray-50">
+                <div class="flex flex-col space-y-6 md:h-full md:justify-between">
+                    <div class="flex justify-between">
+                        <span class="text-xs text-gray-500 font-semibold uppercase tracking-wider">
+                            〇〇 様 アカウント編集
+                        </span>
+                    </div>
+                    <div class="flex gap-2 md:gap-4 justify-between items-center">
+                        <div class="flex flex-col space-y-4">
+                            <div class="flex items-center gap-4">
+                              <%= render 'form', manager: @manager %>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="flex gap-2 md:gap-4">
+                      <%= link_to '戻る', managers_show_path(@manager), class: "bg-blue-600 px-5 py-3 w-full text-center md:w-auto rounded-lg text-white text-xs tracking-wider font-semibold hover:bg-blue-800" %>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>

--- a/app/views/managers/account/edit.html.erb
+++ b/app/views/managers/account/edit.html.erb
@@ -11,12 +11,12 @@
                     <div class="flex gap-2 md:gap-4 justify-between items-center">
                         <div class="flex flex-col space-y-4">
                             <div class="flex items-center gap-4">
-                              <%= render 'form', manager: @manager %>
+                              <%= render 'form', manager: current_manager %>
                             </div>
                         </div>
                     </div>
                     <div class="flex gap-2 md:gap-4">
-                      <%= link_to '戻る', managers_show_path(@manager), class: "bg-blue-600 px-5 py-3 w-full text-center md:w-auto rounded-lg text-white text-xs tracking-wider font-semibold hover:bg-blue-800" %>
+                      <%= link_to '戻る', managers_show_path(current_manager), class: "bg-blue-600 px-5 py-3 w-full text-center md:w-auto rounded-lg text-white text-xs tracking-wider font-semibold hover:bg-blue-800" %>
                     </div>
                 </div>
             </div>

--- a/app/views/managers/account/show.html.erb
+++ b/app/views/managers/account/show.html.erb
@@ -13,7 +13,7 @@
                             <h2 class="text-gray-800 font-bold tracking-widest leading-tight">メールアドレス</h2>
                             <div class="flex items-center gap-4">
                                 <p class="text-lg text-gray-600 tracking-wider">
-                                    <%= @manager.email %>
+                                    <%= current_manager.email %>
                                 </p>
                             </div>
                         </div>

--- a/app/views/managers/account/show.html.erb
+++ b/app/views/managers/account/show.html.erb
@@ -1,0 +1,29 @@
+<main class="container mx-w-6xl mx-auto py-4">
+    <div class="flex flex-col space-y-8">
+        <div class="grid grid-cols-1 md:grid-cols-4 xl:grid-cols-5 px-4 xl:p-0 gap-y-4 md:gap-6">
+            <div class="md:col-span-2 xl:col-span-3 bg-white p-6 rounded-2xl border border-gray-50">
+                <div class="flex flex-col space-y-6 md:h-full md:justify-between">
+                    <div class="flex justify-between">
+                        <span class="text-xs text-gray-500 font-semibold uppercase tracking-wider">
+                            〇〇 様 アカウント詳細
+                        </span>
+                    </div>
+                    <div class="flex gap-2 md:gap-4 justify-between items-center">
+                        <div class="flex flex-col space-y-4">
+                            <h2 class="text-gray-800 font-bold tracking-widest leading-tight">メールアドレス</h2>
+                            <div class="flex items-center gap-4">
+                                <p class="text-lg text-gray-600 tracking-wider">
+                                    <%= @manager.email %>
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="flex gap-2 md:gap-4">
+                      <%= link_to 'アカウントを編集する', managers_edit_path, class: "bg-blue-600 px-5 py-3 w-full text-center md:w-auto rounded-lg text-white text-xs tracking-wider font-semibold hover:bg-blue-800" %>
+                      <%= link_to '戻る', managers_dashboards_path, class: "bg-blue-600 px-5 py-3 w-full text-center md:w-auto rounded-lg text-white text-xs tracking-wider font-semibold hover:bg-blue-800" %>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>

--- a/app/views/managers/dashboards/index.html.erb
+++ b/app/views/managers/dashboards/index.html.erb
@@ -29,10 +29,7 @@
                         </h2> %>
                     </div>
                     <div class="flex gap-2 md:gap-4">
-                        <a href="#"
-                            class="bg-blue-600 px-5 py-3 w-full text-center md:w-auto rounded-lg text-white text-xs tracking-wider font-semibold hover:bg-blue-800">
-                            アカウント編集
-                        </a>
+                        <%= link_to 'アカウント詳細 / 編集', managers_show_path, class: "bg-blue-600 px-5 py-3 w-full text-center md:w-auto rounded-lg text-white text-xs tracking-wider font-semibold hover:bg-blue-800" %>
                         <%# <a href="#"
                             class="bg-blue-50 px-5 py-3 w-full text-center md:w-auto rounded-lg text-blue-600 text-xs tracking-wider font-semibold hover:bg-blue-600 hover:text-white">
                             Link Account

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,12 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
     resources :dashboards, only: [:index]
   end
 
+  namespace :managers do
+    get :show, path: '/account', to: 'account#show'
+    get :edit, path: '/account/edit', to: 'account#edit'
+    patch :update, path: '/account', to: 'account#update'
+  end
+
   namespace :users do
     resources :dashboards, only: [:index]
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -87,4 +87,9 @@ RSpec.configure do |config|
   config.include Devise::Test::IntegrationHelpers, type: :request
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.include Devise::Test::ControllerHelpers, type: :view
+  config.include Devise::Test::IntegrationHelpers, type: :system
+end
+
+def login_manager
+  sign_in FactoryBot.create(:manager)
 end

--- a/spec/requests/managers/account_edit_spec.rb
+++ b/spec/requests/managers/account_edit_spec.rb
@@ -29,9 +29,10 @@ RSpec.describe 'マネージャーアカウントの編集テスト', type: :req
     end
 
     context 'マネージャー詳細編集のパラメータが揃ってい無い場合' do
-      it '更新は失敗するがリクエスト自体はエラーにならないこと' do
+      it '更新できずエラーメッセージが出ること' do
         patch managers_update_path, params: { manager: invalid_manager_params }
-        expect(response.status).to eq 200
+        expect(response.body).to include('エラーが発生したため 管理者 は保存されませんでした。')
+        expect(response.status).to eq 422
       end
 
       it '認証メールが送信されないこと' do

--- a/spec/requests/managers/account_edit_spec.rb
+++ b/spec/requests/managers/account_edit_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe 'マネージャーアカウントの編集テスト', type: :request do
+  let(:manager) { create(:manager) }
+  let(:manager_params) { attributes_for(:manager) }
+  let(:invalid_manager_params) { attributes_for(:manager, email: '') }
+
+  describe 'マネージャーアカウントの編集テスト' do
+    before(:each) do
+      ActionMailer::Base.deliveries.clear
+      login_manager
+    end
+
+    context 'マネージャー詳細編集のパラメータが全て揃っている場合' do
+      it '更新のリクエストが成功すること' do
+        patch managers_update_path, params: { manager: manager_params }
+        expect(response.status).to eq 302
+      end
+
+      it '認証メールが送信されること' do
+        patch managers_update_path, params: { manager: manager_params }
+        expect(ActionMailer::Base.deliveries.size).to eq 1
+      end
+
+      it 'リダイレクトされること' do
+        patch managers_update_path, params: { manager: manager_params }
+        expect(response).to redirect_to managers_show_path
+      end
+    end
+
+    context 'マネージャー詳細編集のパラメータが揃ってい無い場合' do
+      it '更新は失敗するがリクエスト自体はエラーにならないこと' do
+        patch managers_update_path, params: { manager: invalid_manager_params }
+        expect(response.status).to eq 200
+      end
+
+      it '認証メールが送信されないこと' do
+        patch managers_update_path, params: { manager: invalid_manager_params }
+        expect(ActionMailer::Base.deliveries.size).to eq 0
+      end
+    end
+  end
+end

--- a/spec/system/managers/account_edit_spec.rb
+++ b/spec/system/managers/account_edit_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe 'マネージャー詳細の更新', type: :system do
-  before do
+  before(:each) do
     login_manager
   end
 

--- a/spec/system/managers/account_edit_spec.rb
+++ b/spec/system/managers/account_edit_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe 'マネージャー詳細の更新', type: :system do
+  before do
+    login_manager
+  end
+
+  context 'マネージャー詳細の更新' do
+    it '全てのパラメータが入ると詳細の更新が成功することを確認' do
+      visit managers_edit_path
+      fill_in 'manager[email]', with: 'manager@example.com'
+      fill_in 'manager[password]', with: 'password'
+      fill_in 'manager[password_confirmation]', with: 'password'
+      click_button '更新する'
+      expect(page).to have_content 'アカウント詳細'
+    end
+
+    it 'パラメータが入っていないと詳細の更新が失敗することを確認' do
+      visit managers_edit_path
+      fill_in 'manager[email]', with: ''
+      fill_in 'manager[password]', with: ''
+      fill_in 'manager[password_confirmation]', with: ''
+      click_button '更新する'
+      expect(page).to have_content 'アカウント編集'
+    end
+  end
+end


### PR DESCRIPTION
### やったこと
- マネージャーアカウントのルーティングURLを設計資料に沿って作成
- managerのダッシュボードにアカウント詳細画面へのリンクを作成。
- アカウント詳細画面を作成。
- アカウント編集機能を作成。
- アカウント編集画面でメールアドレスとパスワードを編集できるように作成。
- メールアドレスは編集後、認証メールが届き本人認証することで更新できるように作成。
- アカウント更新後はアカウント詳細画面にリダイレクトするように作成。
- 画面遷移の request_spec とアカウント編集の system_spec を作成。

### やらなかったこと
- デザインは特に手を加えていません。

### 確認したこと(UI手動テスト)
- [x] ダッシュボードから編集画面まで画面遷移ができている。
- [x] メールを編集した場合認証メールが届く。
- [x] 認証メールのステップを踏むと編集後のメールアドレスでログインできる。
- [x] パスワードの変更ができること。

### 手動で確認した際の画像
### ログインから編集まで画面遷移の流れ
動画にしたらサイズの問題で添付できず。Slackのレビュー依頼用chに添付しました。
https://nei-tech-course.slack.com/archives/C038DS65NS3/p1648557226209349

- 設計資料に沿ったルーティング
<img width="1366" alt="スクリーンショット 2022-03-29 午後9 35 49" src="https://user-images.githubusercontent.com/36902599/160602686-777e3379-f73f-473b-9cb0-1ed28ccb90cc.png">
<img width="849" alt="スクリーンショット 2022-03-29 午後9 36 07" src="https://user-images.githubusercontent.com/36902599/160602715-195b95b8-2bb8-4afb-a340-9314db9fc867.png">


### その他
特になし。

