### PR TITLE
step3-7[namager]管理者管理機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,9 @@ gem 'sassc-rails'
 # 環境変数を管理する
 gem 'dotenv-rails'
 
+# マネージャーの権限管理
+gem 'cancancan'
+
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,7 @@ GEM
     bullet (7.0.1)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
+    cancancan (3.3.0)
     capybara (3.36.0)
       addressable
       matrix
@@ -373,6 +374,7 @@ DEPENDENCIES
   bootsnap
   brakeman
   bullet
+  cancancan
   capybara
   cssbundling-rails
   database_cleaner

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,11 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit :sign_up, keys: [:email]
+    devise_parameter_sanitizer.permit :sign_up, keys: [:email, :role]
     devise_parameter_sanitizer.permit :sign_in, keys: [:email]
+  end
+
+  def current_ability
+    @current_ability ||= Ability.new(current_manager)
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,7 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit :sign_up, keys: [:email, :role]
+    devise_parameter_sanitizer.permit :sign_up, keys: %i[email role]
     devise_parameter_sanitizer.permit :sign_in, keys: [:email]
   end
 

--- a/app/controllers/managers/account_controller.rb
+++ b/app/controllers/managers/account_controller.rb
@@ -17,6 +17,7 @@ module Managers
     end
 
     private
+
     def manager_params
       params.require(:manager).permit(:email, :password, :password_confirmation)
     end

--- a/app/controllers/managers/account_controller.rb
+++ b/app/controllers/managers/account_controller.rb
@@ -16,6 +16,7 @@ module Managers
       end
     end
 
+    private
     def manager_params
       params.require(:manager).permit(:email, :password, :password_confirmation)
     end

--- a/app/controllers/managers/general_managers_controller.rb
+++ b/app/controllers/managers/general_managers_controller.rb
@@ -16,7 +16,7 @@ module Managers
     end
 
     def create
-      if @manager = Manager.create(manager_params)
+      if (@manager = Manager.create(manager_params))
         sign_in(current_manager, bypass: true)
         redirect_to managers_general_manager_path(@manager)
       else

--- a/app/controllers/managers/general_managers_controller.rb
+++ b/app/controllers/managers/general_managers_controller.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Managers
+  # 管理者のアカウント
+  class GeneralManagersController < Managers::Base
+    before_action :set_manager, only: %i[show edit update destroy]
+
+    def index
+      @managers = Manager.all
+    end
+
+    def show; end
+
+    def new
+      @manager = Manager.new
+    end
+
+    def create
+      if @manager = Manager.create(manager_params)
+        sign_in(current_manager, bypass: true)
+        redirect_to managers_general_manager_path(@manager)
+      else
+        render :new, status: :unprocessable_entity
+      end
+    end
+
+    def edit; end
+
+    def update
+      if @manager.update(manager_params)
+        sign_in(current_manager, bypass: true)
+        redirect_to managers_general_manager_path(@manager)
+      else
+        render :edit, status: :unprocessable_entity
+      end
+    end
+
+    def destroy
+      if @manager.destroy
+        sign_in(current_manager, bypass: true)
+        redirect_to managers_general_managers_path, status: :see_other
+      else
+        render :show, status: :unprocessable_entity
+      end
+    end
+
+    private
+
+    def set_manager
+      @manager = Manager.find(params[:id])
+    end
+
+    def manager_params
+      params.require(:manager).permit(:email, :password, :password_confirmation)
+    end
+  end
+end

--- a/app/controllers/managers/registrations_controller.rb
+++ b/app/controllers/managers/registrations_controller.rb
@@ -13,9 +13,14 @@ module Managers
     # end
 
     # POST /resource
-    # def create
-    #   super
-    # end
+    def create
+      if Manager.exists?(role: 'admin')
+        redirect_to new_manager_registration_path
+        flash[:alert] = 'admin権限のマネージャーが既に存在しています。'
+      else
+        super
+      end
+    end
 
     # GET /resource/edit
     # def edit

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,7 +2,7 @@
 
 # アプリケーション共通のヘルパ
 module ApplicationHelper
-  def exit_admin_manager
+  def admin_manager_exists?
     Manager.exists?(role: 'admin')
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,4 +2,7 @@
 
 # アプリケーション共通のヘルパ
 module ApplicationHelper
+  def exit_admin_manager
+    Manager.exists?(role: 'admin')
+  end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -4,11 +4,12 @@ class Ability
   include CanCan::Ability
 
   def initialize(manager)
-    if manager.role == 'admin'
+    case manager.role
+    when 'admin'
       can :manage, :all
       # adminはフル権限
 
-    elsif manager.role == 'gengeral'
+    when 'gengeral'
       can :read, :all
       # gengeralは閲覧のみ可能
     end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+class Ability
+  include CanCan::Ability
+
+  def initialize(manager)
+    if manager.role == 'admin'
+      can :manage, :all
+      # adminはフル権限
+
+    elsif manager.role == 'gengeral'
+      can :read, :all
+      # gengeralは閲覧のみ可能
+    end
+
+    # Define abilities for the passed in user here. For example:
+    #
+    #   user ||= User.new # guest user (not logged in)
+    #   if user.admin?
+    #     can :manage, :all
+    #   else
+    #     can :read, :all
+    #   end
+    #
+    # The first argument to `can` is the action you are giving the user
+    # permission to do.
+    # If you pass :manage it will apply to every action. Other common actions
+    # here are :read, :create, :update and :destroy.
+    #
+    # The second argument is the resource the user can perform the action on.
+    # If you pass :all it will apply to every resource. Otherwise pass a Ruby
+    # class of the resource.
+    #
+    # The third argument is an optional hash of conditions to further filter the
+    # objects.
+    # For example, here the user can only update published articles.
+    #
+    #   can :update, Article, :published => true
+    #
+    # See the wiki for details:
+    # https://github.com/CanCanCommunity/cancancan/wiki/Defining-Abilities
+  end
+end

--- a/app/views/managers/dashboards/index.html.erb
+++ b/app/views/managers/dashboards/index.html.erb
@@ -31,6 +31,7 @@
                     <div class="flex gap-2 md:gap-4">
                         <%= link_to 'アカウント詳細 / 編集', managers_show_path, class: "bg-blue-600 px-5 py-3 w-full text-center md:w-auto rounded-lg text-white text-xs tracking-wider font-semibold hover:bg-blue-800" %>
                         <%= link_to 'ユーザー一覧', managers_users_path, class: "bg-blue-600 px-5 py-3 w-full text-center md:w-auto rounded-lg text-white text-xs tracking-wider font-semibold hover:bg-blue-800" %>
+                        <%= link_to 'マネージャー一覧', managers_general_managers_path, class: "bg-blue-600 px-5 py-3 w-full text-center md:w-auto rounded-lg text-white text-xs tracking-wider font-semibold hover:bg-blue-800" %>
                         <%# <a href="#"
                             class="bg-blue-50 px-5 py-3 w-full text-center md:w-auto rounded-lg text-blue-600 text-xs tracking-wider font-semibold hover:bg-blue-600 hover:text-white">
                             Link Account

--- a/app/views/managers/general_managers/_form_edit.html.erb
+++ b/app/views/managers/general_managers/_form_edit.html.erb
@@ -1,0 +1,16 @@
+<%= form_with(model: manager, url: managers_general_manager_path, local: true, method: :patch) do |form| %>
+  <%= render "managers/shared/error_messages", resource: manager %>
+  <div class="mb-6 pt-3 rounded bg-gray-200">
+    <%= form.label :email, class: "text-gray-700 text-sm font-bold mb-2 ml-3" %>
+    <%= form.email_field :email, autofocus: true, autocomplete: "email", class: "bg-gray-200 rounded w-full text-gray-700 focus:outline-none border-b-4 border-gray-300 focus:border-purple-600 transition duration-500 px-3 pb-3" %>
+  </div>
+  <div class="mb-6 pt-3 rounded bg-gray-200">
+    <%= form.label :password, class: "text-gray-700 text-sm font-bold mb-2 ml-3" %>
+    <%= form.password_field :password, autocomplete: "current-password", class: "bg-gray-200 rounded w-full text-gray-700 focus:outline-none border-b-4 border-gray-300 focus:border-purple-600 transition duration-500 px-3 pb-3" %>
+  </div>
+  <div class="mb-6 pt-3 rounded bg-gray-200">
+    <%= form.label :password_confirmation, class: "text-gray-700 text-sm font-bold mb-2 ml-3" %>
+    <%= form.password_field :password_confirmation, autocomplete: "current-password", class: "bg-gray-200 rounded w-full text-gray-700 focus:outline-none border-b-4 border-gray-300 focus:border-purple-600 transition duration-500 px-3 pb-3" %>
+  </div>
+  <%= form.submit class: "bg-blue-600 px-5 py-3 w-full text-center md:w-auto rounded-lg text-white text-xs tracking-wider font-semibold hover:bg-blue-800" %>
+<% end %>

--- a/app/views/managers/general_managers/_form_new.html.erb
+++ b/app/views/managers/general_managers/_form_new.html.erb
@@ -1,0 +1,16 @@
+<%= form_with(model: manager, url: managers_general_managers_path, local: true, method: :post) do |form| %>
+  <%= render "managers/shared/error_messages", resource: manager %>
+  <div class="mb-6 pt-3 rounded bg-gray-200">
+    <%= form.label :email, class: "text-gray-700 text-sm font-bold mb-2 ml-3" %>
+    <%= form.email_field :email, autofocus: true, autocomplete: "email", class: "bg-gray-200 rounded w-full text-gray-700 focus:outline-none border-b-4 border-gray-300 focus:border-purple-600 transition duration-500 px-3 pb-3" %>
+  </div>
+  <div class="mb-6 pt-3 rounded bg-gray-200">
+    <%= form.label :password, class: "text-gray-700 text-sm font-bold mb-2 ml-3" %>
+    <%= form.password_field :password, autocomplete: "current-password", class: "bg-gray-200 rounded w-full text-gray-700 focus:outline-none border-b-4 border-gray-300 focus:border-purple-600 transition duration-500 px-3 pb-3" %>
+  </div>
+  <div class="mb-6 pt-3 rounded bg-gray-200">
+    <%= form.label :password_confirmation, class: "text-gray-700 text-sm font-bold mb-2 ml-3" %>
+    <%= form.password_field :password_confirmation, autocomplete: "current-password", class: "bg-gray-200 rounded w-full text-gray-700 focus:outline-none border-b-4 border-gray-300 focus:border-purple-600 transition duration-500 px-3 pb-3" %>
+  </div>
+  <%= form.submit class: "bg-blue-600 px-5 py-3 w-full text-center md:w-auto rounded-lg text-white text-xs tracking-wider font-semibold hover:bg-blue-800" %>
+<% end %>

--- a/app/views/managers/general_managers/_form_new.html.erb
+++ b/app/views/managers/general_managers/_form_new.html.erb
@@ -2,15 +2,15 @@
   <%= render "managers/shared/error_messages", resource: manager %>
   <div class="mb-6 pt-3 rounded bg-gray-200">
     <%= form.label :email, class: "text-gray-700 text-sm font-bold mb-2 ml-3" %>
-    <%= form.email_field :email, autofocus: true, autocomplete: "email", class: "bg-gray-200 rounded w-full text-gray-700 focus:outline-none border-b-4 border-gray-300 focus:border-purple-600 transition duration-500 px-3 pb-3" %>
+    <%= form.email_field :email, autofocus: true, autocomplete: "email", required: true, class: "bg-gray-200 rounded w-full text-gray-700 focus:outline-none border-b-4 border-gray-300 focus:border-purple-600 transition duration-500 px-3 pb-3" %>
   </div>
   <div class="mb-6 pt-3 rounded bg-gray-200">
     <%= form.label :password, class: "text-gray-700 text-sm font-bold mb-2 ml-3" %>
-    <%= form.password_field :password, autocomplete: "current-password", class: "bg-gray-200 rounded w-full text-gray-700 focus:outline-none border-b-4 border-gray-300 focus:border-purple-600 transition duration-500 px-3 pb-3" %>
+    <%= form.password_field :password, autocomplete: "current-password", required: true, class: "bg-gray-200 rounded w-full text-gray-700 focus:outline-none border-b-4 border-gray-300 focus:border-purple-600 transition duration-500 px-3 pb-3" %>
   </div>
   <div class="mb-6 pt-3 rounded bg-gray-200">
     <%= form.label :password_confirmation, class: "text-gray-700 text-sm font-bold mb-2 ml-3" %>
-    <%= form.password_field :password_confirmation, autocomplete: "current-password", class: "bg-gray-200 rounded w-full text-gray-700 focus:outline-none border-b-4 border-gray-300 focus:border-purple-600 transition duration-500 px-3 pb-3" %>
+    <%= form.password_field :password_confirmation, autocomplete: "current-password", required: true, class: "bg-gray-200 rounded w-full text-gray-700 focus:outline-none border-b-4 border-gray-300 focus:border-purple-600 transition duration-500 px-3 pb-3" %>
   </div>
   <%= form.submit class: "bg-blue-600 px-5 py-3 w-full text-center md:w-auto rounded-lg text-white text-xs tracking-wider font-semibold hover:bg-blue-800" %>
 <% end %>

--- a/app/views/managers/general_managers/edit.html.erb
+++ b/app/views/managers/general_managers/edit.html.erb
@@ -1,0 +1,25 @@
+<main class="container mx-w-6xl mx-auto py-4">
+    <div class="flex flex-col space-y-8">
+        <div class="grid grid-cols-1 md:grid-cols-4 xl:grid-cols-5 px-4 xl:p-0 gap-y-4 md:gap-6">
+            <div class="md:col-span-2 xl:col-span-3 bg-white p-6 rounded-2xl border border-gray-50">
+                <div class="flex flex-col space-y-6 md:h-full md:justify-between">
+                    <div class="flex justify-between">
+                        <span class="text-xs text-gray-500 font-semibold uppercase tracking-wider">
+                            〇〇 様 アカウント編集
+                        </span>
+                    </div>
+                    <div class="flex gap-2 md:gap-4 justify-between items-center">
+                        <div class="flex flex-col space-y-4">
+                            <div class="flex items-center gap-4">
+                              <%= render 'form_edit', manager: @manager %>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="flex gap-2 md:gap-4">
+                      <%= link_to '戻る', managers_general_manager_path(@manager.id), class: "bg-blue-600 px-5 py-3 w-full text-center md:w-auto rounded-lg text-white text-xs tracking-wider font-semibold hover:bg-blue-800" %>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>

--- a/app/views/managers/general_managers/index.html.erb
+++ b/app/views/managers/general_managers/index.html.erb
@@ -1,0 +1,38 @@
+<main class="container mx-w-6xl mx-auto py-4">
+    <div class="flex flex-col space-y-8">
+        <div class="grid grid-cols-1 md:grid-cols-4 xl:grid-cols-5 px-4 xl:p-0 gap-y-4 md:gap-6">
+            <div class="md:col-span-2 xl:col-span-3 bg-white p-6 rounded-2xl border border-gray-50">
+                <div class="flex flex-col space-y-6 md:h-full md:justify-between">
+                    <div class="flex justify-between">
+                        <span class="text-xs text-gray-500 font-semibold uppercase tracking-wider">
+                            マネージャー一覧
+                        </span>
+                    </div>
+                      <table class="table-fixed">
+                        <thead>
+                          <tr>
+                            <th>ID</th>
+                            <th>Email</th>
+                            <th>詳細</th>
+                          </tr>
+                        </thead>
+
+                        <tbody>
+                          <% @managers.each do |manager| %>
+                            <tr class="border-4 border-gray-200 text-center">
+                              <td><%= manager.id %></td>
+                              <td><%= manager.email %></td>
+                              <td><%= link_to '詳細', managers_general_manager_path(manager.id), class: "bg-blue-600 px-4 py-1 w-full text-center md:w-auto rounded-lg text-white text-xs tracking-wider font-semibold hover:bg-blue-800" %></td>
+                            </tr>
+                          <% end %>
+                        </tbody>
+                      </table>
+                    <div class="flex gap-2 md:gap-4">
+                      <%= link_to 'マネージャー新規作成', new_managers_general_manager_path, class: "bg-blue-600 px-5 py-3 w-full text-center md:w-auto rounded-lg text-white text-xs tracking-wider font-semibold hover:bg-blue-800" %>
+                      <%= link_to '戻る', managers_dashboards_path, class: "bg-blue-600 px-5 py-3 w-full text-center md:w-auto rounded-lg text-white text-xs tracking-wider font-semibold hover:bg-blue-800" %>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>

--- a/app/views/managers/general_managers/index.html.erb
+++ b/app/views/managers/general_managers/index.html.erb
@@ -28,7 +28,9 @@
                         </tbody>
                       </table>
                     <div class="flex gap-2 md:gap-4">
-                      <%= link_to 'マネージャー新規作成', new_managers_general_manager_path, class: "bg-blue-600 px-5 py-3 w-full text-center md:w-auto rounded-lg text-white text-xs tracking-wider font-semibold hover:bg-blue-800" %>
+                      <% if can?  :create, current_manager %>
+                        <%= link_to 'マネージャー新規作成', new_managers_general_manager_path, class: "bg-blue-600 px-5 py-3 w-full text-center md:w-auto rounded-lg text-white text-xs tracking-wider font-semibold hover:bg-blue-800" %>
+                      <% end %>
                       <%= link_to '戻る', managers_dashboards_path, class: "bg-blue-600 px-5 py-3 w-full text-center md:w-auto rounded-lg text-white text-xs tracking-wider font-semibold hover:bg-blue-800" %>
                     </div>
                 </div>

--- a/app/views/managers/general_managers/new.html.erb
+++ b/app/views/managers/general_managers/new.html.erb
@@ -1,0 +1,25 @@
+<main class="container mx-w-6xl mx-auto py-4">
+    <div class="flex flex-col space-y-8">
+        <div class="grid grid-cols-1 md:grid-cols-4 xl:grid-cols-5 px-4 xl:p-0 gap-y-4 md:gap-6">
+            <div class="md:col-span-2 xl:col-span-3 bg-white p-6 rounded-2xl border border-gray-50">
+                <div class="flex flex-col space-y-6 md:h-full md:justify-between">
+                    <div class="flex justify-between">
+                        <span class="text-xs text-gray-500 font-semibold uppercase tracking-wider">
+                            マネージャー新規作成
+                        </span>
+                    </div>
+                    <div class="flex gap-2 md:gap-4 justify-between items-center">
+                        <div class="flex flex-col space-y-4">
+                            <div class="flex items-center gap-4">
+                              <%= render 'form_new', manager: @manager %>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="flex gap-2 md:gap-4">
+                      <%= link_to '戻る', managers_general_managers_path, class: "bg-blue-600 px-5 py-3 w-full text-center md:w-auto rounded-lg text-white text-xs tracking-wider font-semibold hover:bg-blue-800" %>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>

--- a/app/views/managers/general_managers/show.html.erb
+++ b/app/views/managers/general_managers/show.html.erb
@@ -1,0 +1,36 @@
+<main class="container mx-w-6xl mx-auto py-4">
+    <div class="flex flex-col space-y-8">
+        <div class="grid grid-cols-1 md:grid-cols-4 xl:grid-cols-5 px-4 xl:p-0 gap-y-4 md:gap-6">
+            <div class="md:col-span-2 xl:col-span-3 bg-white p-6 rounded-2xl border border-gray-50">
+                <div class="flex flex-col space-y-6 md:h-full md:justify-between">
+                    <div class="flex justify-between">
+                        <span class="text-xs text-gray-500 font-semibold uppercase tracking-wider">
+                            マネージャー詳細
+                        </span>
+                    </div>
+                    <div class="flex gap-2 md:gap-4 justify-between items-center">
+                        <div class="flex flex-col space-y-4">
+                            <h2 class="text-gray-800 font-bold tracking-widest leading-tight">ID</h2>
+                            <div class="flex items-center gap-4">
+                                <p class="text-lg text-gray-600 tracking-wider">
+                                    <%= @manager.id %>
+                                </p>
+                            </div>
+                            <h2 class="text-gray-800 font-bold tracking-widest leading-tight">メールアドレス</h2>
+                            <div class="flex items-center gap-4">
+                                <p class="text-lg text-gray-600 tracking-wider">
+                                    <%= @manager.email %>
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="flex gap-2 md:gap-4">
+                      <%= link_to 'アカウントを編集する', edit_managers_general_manager_path(@manager.id), class: "bg-blue-600 px-5 py-3 w-full text-center md:w-auto rounded-lg text-white text-xs tracking-wider font-semibold hover:bg-blue-800" %>
+                      <%= link_to 'アカウントを削除する', managers_general_manager_path, data: { turbo_method: :delete, turbo_confirm: '削除してもよろしいですか?' }, class: "bg-purple-600 px-5 py-3 w-full text-center md:w-auto rounded-lg text-white text-xs tracking-wider font-semibold hover:bg-blue-800" %>
+                      <%= link_to '戻る', managers_general_managers_path, class: "bg-blue-600 px-5 py-3 w-full text-center md:w-auto rounded-lg text-white text-xs tracking-wider font-semibold hover:bg-blue-800" %>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</main>

--- a/app/views/managers/general_managers/show.html.erb
+++ b/app/views/managers/general_managers/show.html.erb
@@ -25,8 +25,12 @@
                         </div>
                     </div>
                     <div class="flex gap-2 md:gap-4">
+                    <% if can?  :update, current_manager %>
                       <%= link_to 'アカウントを編集する', edit_managers_general_manager_path(@manager.id), class: "bg-blue-600 px-5 py-3 w-full text-center md:w-auto rounded-lg text-white text-xs tracking-wider font-semibold hover:bg-blue-800" %>
+                    <% end %>
+                    <% if can?  :destroy, current_manager %>
                       <%= link_to 'アカウントを削除する', managers_general_manager_path, data: { turbo_method: :delete, turbo_confirm: '削除してもよろしいですか?' }, class: "bg-purple-600 px-5 py-3 w-full text-center md:w-auto rounded-lg text-white text-xs tracking-wider font-semibold hover:bg-blue-800" %>
+                    <% end %>
                       <%= link_to '戻る', managers_general_managers_path, class: "bg-blue-600 px-5 py-3 w-full text-center md:w-auto rounded-lg text-white text-xs tracking-wider font-semibold hover:bg-blue-800" %>
                     </div>
                 </div>

--- a/app/views/managers/general_managers/show.html.erb
+++ b/app/views/managers/general_managers/show.html.erb
@@ -29,7 +29,7 @@
                       <%= link_to 'アカウントを編集する', edit_managers_general_manager_path(@manager.id), class: "bg-blue-600 px-5 py-3 w-full text-center md:w-auto rounded-lg text-white text-xs tracking-wider font-semibold hover:bg-blue-800" %>
                     <% end %>
                     <% if can?  :destroy, current_manager %>
-                      <%= link_to 'アカウントを削除する', managers_general_manager_path, data: { turbo_method: :delete, turbo_confirm: '削除してもよろしいですか?' }, class: "bg-purple-600 px-5 py-3 w-full text-center md:w-auto rounded-lg text-white text-xs tracking-wider font-semibold hover:bg-blue-800" %>
+                      <%= link_to 'アカウントを削除する', managers_general_manager_path(@manager.id), data: { turbo_method: :delete, turbo_confirm: '削除してもよろしいですか?' }, class: "bg-purple-600 px-5 py-3 w-full text-center md:w-auto rounded-lg text-white text-xs tracking-wider font-semibold hover:bg-blue-800" %>
                     <% end %>
                       <%= link_to '戻る', managers_general_managers_path, class: "bg-blue-600 px-5 py-3 w-full text-center md:w-auto rounded-lg text-white text-xs tracking-wider font-semibold hover:bg-blue-800" %>
                     </div>

--- a/app/views/managers/registrations/new.html.erb
+++ b/app/views/managers/registrations/new.html.erb
@@ -6,7 +6,11 @@
   <%= render "managers/shared/error_messages", resource: resource %>
 
   <section class="mt-10">
+    <% if exit_admin_manager %>
+      <%= 'admin権限のマネージャーが既に存在しています。'%>
+    <% else %>
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name), data: { turbo: false }, class: "flex flex-col") do |f| %>
+        <%= f.hidden_field :role, value: 'admin' %>
       <div class="mb-6 pt-3 rounded bg-gray-200">
         <%= f.label :email, class: "block text-gray-700 text-sm font-bold mb-2 ml-3" %>
         <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "bg-gray-200 rounded w-full text-gray-700 focus:outline-none border-b-4 border-gray-300 focus:border-purple-600 transition duration-500 px-3 pb-3" %>
@@ -30,6 +34,7 @@
       <% end %>
       <%= render "managers/shared/links" %>
       <%= f.submit t('.sign_up'), class: "bg-purple-600 hover:bg-purple-700 text-white font-bold py-2 rounded shadow-lg hover:shadow-xl transition duration-200" %>
+    <% end %>
     <% end %>
   </section>
 </main>

--- a/app/views/managers/registrations/new.html.erb
+++ b/app/views/managers/registrations/new.html.erb
@@ -6,7 +6,7 @@
   <%= render "managers/shared/error_messages", resource: resource %>
 
   <section class="mt-10">
-    <% if exit_admin_manager %>
+    <% if admin_manager_exists? %>
       <%= 'admin権限のマネージャーが既に存在しています。'%>
     <% else %>
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name), data: { turbo: false }, class: "flex flex-col") do |f| %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,7 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
 
   namespace :managers do
     resources :dashboards, only: [:index]
+    resources :general_managers
     resources :users, only: %i[index show]
     get :show, path: '/account', to: 'account#show'
     get :edit, path: '/account/edit', to: 'account#edit'

--- a/db/migrate/20220331061338_add_role_to_managers.rb
+++ b/db/migrate/20220331061338_add_role_to_managers.rb
@@ -1,0 +1,5 @@
+class AddRoleToManagers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :managers, :role, :string, null: false, default: 'gengeral'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_02_28_224503) do
+ActiveRecord::Schema[7.0].define(version: 2022_03_31_061338) do
   create_table "admins", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -35,6 +35,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_02_28_224503) do
     t.string "unconfirmed_email"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "role", default: "gengeral", null: false
     t.index ["email"], name: "index_managers_on_email", unique: true
     t.index ["reset_password_token"], name: "index_managers_on_reset_password_token", unique: true
   end

--- a/spec/factories/managers.rb
+++ b/spec/factories/managers.rb
@@ -6,5 +6,6 @@ FactoryBot.define do
     password { 'password' }
     password_confirmation { 'password' }
     confirmed_at { Date.today }
+    role { 'admin' }
   end
 end

--- a/spec/requests/managers/general_managers_spec.rb
+++ b/spec/requests/managers/general_managers_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+RSpec.describe 'ジェネラルマネージャーのCRUDテスト', type: :request do
+  let(:manager) { create(:manager) }
+  let(:manager_params) { attributes_for(:manager) }
+  let(:invalid_manager_params) { attributes_for(:manager, email: '') }
+
+  before(:each) do
+    ActionMailer::Base.deliveries.clear
+    login_manager
+  end
+
+  describe 'ジェネラルマネージャー新規作成テスト' do
+    context 'パラメータが全て揃っている場合' do
+      it '新規作成のリクエストが成功すること' do
+        post managers_general_managers_path, params: { manager: manager_params }
+        expect(response.status).to eq 302
+      end
+
+      it '認証メールが送信されること' do
+        post managers_general_managers_path, params: { manager: manager_params }
+        expect(ActionMailer::Base.deliveries.size).to eq 1
+      end
+    end
+  end
+
+  describe 'ジェネラルマネージャー編集テスト' do
+    context 'パラメータが全て揃っている場合' do
+      it '更新のリクエストが成功すること' do
+        patch managers_general_manager_path(manager.id), params: { manager: manager_params }
+        expect(response.status).to eq 302
+      end
+
+      it '認証メールが送信されること' do
+        patch managers_general_manager_path(manager.id), params: { manager: manager_params }
+        expect(ActionMailer::Base.deliveries.size).to eq 1
+      end
+    end
+
+    context 'パラメータが揃ってい無い場合' do
+      it '更新できずエラーメッセージが出ること' do
+        patch managers_general_manager_path(manager.id), params: { manager: invalid_manager_params }
+        expect(response.body).to include('エラーが発生したため 管理者 は保存されませんでした。')
+        expect(response.status).to eq 422
+      end
+
+      it '認証メールが送信されないこと' do
+        patch managers_general_manager_path(manager.id), params: { manager: invalid_manager_params }
+        expect(ActionMailer::Base.deliveries.size).to eq 0
+      end
+    end
+  end
+
+  describe 'ジェネラルマネージャー削除テスト' do
+    let!(:manager) { create(:manager) }
+
+    before(:each) do
+      delete managers_general_manager_path(manager.id)
+    end
+
+    it 'マネージャーが削除されたこと' do
+      expect(Manager.where(id: manager.id).size).to be_zero
+    end
+  end
+end

--- a/spec/requests/managers/registration_spec.rb
+++ b/spec/requests/managers/registration_spec.rb
@@ -50,5 +50,20 @@ RSpec.describe 'マネージャー登録から認証メールの送信テスト'
         }.not_to change(Manager, :count)
       end
     end
+
+    context 'Adminマネージャーが登録済みな場合' do
+      let!(:manager) { create(:manager) }
+
+      it 'リダイレクトされること' do
+        post manager_registration_path, params: { manager: manager_params }
+        expect(response.status).to eq 302
+      end
+
+      it '登録されないこと' do
+        expect {
+          post manager_registration_path, params: { manager: manager_params }
+        }.not_to change(Manager, :count)
+      end
+    end
   end
 end

--- a/spec/system/managers/general_managers_spec.rb
+++ b/spec/system/managers/general_managers_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe 'ジェネラルマネージャーのCRUD画面遷移', type: :system do
+  let(:manager) { create(:manager) }
+
+  before(:each) do
+    login_manager
+  end
+
+  context 'ジェネラルマネージャーのCRUD画面遷移' do
+    it 'ジェネラルマネージャーを新規作成できることを確認' do
+      visit new_managers_general_manager_path
+      fill_in 'manager[email]', with: 'manager@example.com'
+      fill_in 'manager[password]', with: 'password'
+      fill_in 'manager[password_confirmation]', with: 'password'
+      click_button '登録する'
+      expect(page).to have_content 'マネージャー詳細'
+    end
+
+    it 'ジェネラルマネージャーを編集できることを確認' do
+      visit edit_managers_general_manager_path(manager.id)
+      fill_in 'manager[email]', with: 'manager@example.com'
+      fill_in 'manager[password]', with: 'password'
+      fill_in 'manager[password_confirmation]', with: 'password'
+      click_button '更新する'
+      expect(page).to have_content 'マネージャー詳細'
+    end
+
+    it 'ジェネラルマネージャーを削除できることを確認' do
+      visit managers_general_manager_path(manager.id)
+      click_link 'アカウントを削除する'
+      expect(page.accept_confirm).to eq '削除してもよろしいですか?'
+      expect(page).to have_content 'マネージャー一覧'
+    end
+  end
+end

--- a/spec/system/managers/registration_spec.rb
+++ b/spec/system/managers/registration_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe 'Adminマネージャー登録', type: :system do
+  context 'Adminマネージャー登録ができることを確認' do
+    it 'Adminマネージャー登録ができることを確認' do
+      visit new_manager_registration_path
+      fill_in 'manager[email]', with: 'manager@example.com'
+      fill_in 'manager[password]', with: 'password'
+      fill_in 'manager[password_confirmation]', with: 'password'
+      click_button 'アカウント登録'
+      expect(page).to have_content 'ログイン'
+    end
+  end
+
+  context 'Adminマネージャーを登録後、再登録できないことを確認' do
+    let!(:manager) { create(:manager) }
+
+    it '登録画面にフォームが存在指定なことを確認' do
+      visit new_manager_registration_path
+      expect(page).to have_content 'admin権限のマネージャーが既に存在しています。'
+    end
+  end
+end

--- a/spec/system/managers/users_spec.rb
+++ b/spec/system/managers/users_spec.rb
@@ -1,21 +1,22 @@
 require 'rails_helper'
 
 RSpec.describe 'マネージャーアカウント内でのユーザー管理テスト', type: :system do
+  let(:user) { create(:user) }
+
   before(:each) do
-    let(:user) { create(:user) }
     login_manager
   end
 
   context 'ユーザー一覧から詳細までの画面遷移テスト' do
     it 'ユーザー一覧ページに行けることを確認' do
       visit managers_dashboards_path
-      click_button 'ユーザー一覧'
+      click_link 'ユーザー一覧'
       expect(page).to have_content 'ユーザー一覧'
     end
 
     it 'ユーザー一覧ページから各ユーザーの詳細ページに行けることを確認' do
       visit managers_users_path(user.id)
-      click_button '詳細'
+      click_link '詳細'
       expect(page).to have_content 'ユーザー詳細'
       expect(page).to have_content user.email.to_s
     end


### PR DESCRIPTION
### やったこと
- manager モデルに gem ‘cancancan’ を使用して、admin 権限とgeneral 権限を作成。
- managers/new では一人のmanagerしか作れないように作成。
- Admin manger のCRUD機能を作成。一般管理者(general_manager)はCRUDができない。
- 画面遷移の system_spec とCRUD機能の request_spec を作成。

### やらなかったこと
- デザインは特に手を加えていません。

### 確認したこと(UI手動テスト)
- [x] 最初に登録するマネージャーのみ Admin 権限になるように設定。以降は managers/sign_up 画面でマネージャーは作れないようになっている。
- [x] Admin 権限のマネージャーでログイン後にジェネラルマネージャーのCRUDができる。
- [x] ジェネラルマネージャーはCRUD操作ができないようになっている。

### 手動で確認した際の画像
動画にしたらサイズの問題で添付できず。Slackのレビュー依頼用chに添付しました。
- 最初のマネージャーを登録後、再度マネージャー登録画面にいくと登録できない状態になっている所まで。
- Admin 権限のマネージャーでCRUD操作をして画面遷移を確認している所。
- ジェネラルマネージャーでログイン後各CRUDアクションのボタンが表示されていないのを確認する所。
https://nei-tech-course.slack.com/archives/C038DS65NS3/p1648730090619089

- 設計資料に沿ったルーティング
<img width="1407" alt="スクリーンショット 2022-03-31 午後10 20 21" src="https://user-images.githubusercontent.com/36902599/161053356-9c0cf16c-fbf3-48e0-8aae-33e422d6da5a.png">
<img width="848" alt="スクリーンショット 2022-03-31 午後10 19 52" src="https://user-images.githubusercontent.com/36902599/161053405-ccf21c33-300a-4de5-8fea-b18ed28a0b5c.png">


### その他
特になし。
