### PR TITLE
step3-9bookテーブルの作成とrspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -103,6 +103,7 @@ group :test do
   gem 'turnip'
   gem 'webdrivers' # 追記
   gem 'webrick'
+  gem 'faker' # ダミーデータの作成
 
   # カバレッジ測定ツール
   gem 'simplecov'

--- a/Gemfile
+++ b/Gemfile
@@ -98,12 +98,12 @@ end
 group :test do
   # 結合テスト用ツール
   gem 'capybara'
+  gem 'faker' # ダミーデータの作成
   gem 'launchy', '~> 2.4.3' # 追記
   gem 'selenium-webdriver'
   gem 'turnip'
   gem 'webdrivers' # 追記
   gem 'webrick'
-  gem 'faker' # ダミーデータの作成
 
   # カバレッジ測定ツール
   gem 'simplecov'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,6 +133,8 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
+    faker (2.20.0)
+      i18n (>= 1.8.11, < 2)
     ffi (1.15.5)
     globalid (1.0.0)
       activesupport (>= 5.0)
@@ -384,6 +386,7 @@ DEPENDENCIES
   devise-i18n-views
   dotenv-rails
   factory_bot_rails
+  faker
   jbuilder
   jsbundling-rails
   launchy (~> 2.4.3)

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -1,0 +1,12 @@
+class Book < ApplicationRecord
+  before_create -> { self.uuid = SecureRandom.uuid }
+  attribute :uuid, :string, default: -> { SecureRandom.uuid }
+
+  validates :uuid, {presence: true}
+  validates :title, {presence: true, length : {maximum:30}}
+  validates :page_size, {presence: true}
+
+  def to_param
+    uuid
+  end
+end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -2,9 +2,9 @@ class Book < ApplicationRecord
   before_create -> { self.uuid = SecureRandom.uuid }
   attribute :uuid, :string, default: -> { SecureRandom.uuid }
 
-  validates :uuid, {presence: true}
-  validates :title, {presence: true, length : {maximum:30}}
-  validates :page_size, {presence: true}
+  validates :uuid, { presence: true }
+  validates :title, { presence: true, length: { maximum: 30 } }
+  validates :page_size, { presence: true }
 
   def to_param
     uuid

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,7 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
   end
 
   namespace :managers do
+    resources :books, param: :uuid
     resources :dashboards, only: [:index]
     resources :general_managers
     resources :users, only: %i[index show]

--- a/db/migrate/20220401113021_create_books.rb
+++ b/db/migrate/20220401113021_create_books.rb
@@ -1,0 +1,15 @@
+class CreateBooks < ActiveRecord::Migration[7.0]
+  def change
+    create_table :books, id: false do |t|
+      t.string :uuid, null: false, primary_key: true
+      t.string :title, null: false, limit: 30
+      t.string :auther
+      t.string :publisher
+      t.date :published_on
+      t.string :series
+      t.integer :page_size, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_03_31_061338) do
+ActiveRecord::Schema[7.0].define(version: 2022_04_01_113021) do
   create_table "admins", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -21,6 +21,17 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_31_061338) do
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_admins_on_email", unique: true
     t.index ["reset_password_token"], name: "index_admins_on_reset_password_token", unique: true
+  end
+
+  create_table "books", primary_key: "uuid", id: :string, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "title", limit: 30, null: false
+    t.string "auther"
+    t.string "publisher"
+    t.date "published_on"
+    t.string "series"
+    t.integer "page_size", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "managers", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|

--- a/spec/factories/books.rb
+++ b/spec/factories/books.rb
@@ -1,11 +1,11 @@
 FactoryBot.define do
   factory :book do
-    uuid { "MyString" }
-    title { "MyString" }
-    auther { "MyString" }
-    publisher { "MyString" }
-    published_on { "2022-04-01" }
-    series { "MyString" }
+    uuid { 'MyString' }
+    title { 'MyString' }
+    auther { 'MyString' }
+    publisher { 'MyString' }
+    published_on { '2022-04-01' }
+    series { 'MyString' }
     page_size { 1 }
   end
 end

--- a/spec/factories/books.rb
+++ b/spec/factories/books.rb
@@ -1,11 +1,11 @@
 FactoryBot.define do
   factory :book do
-    uuid { 'MyString' }
-    title { 'MyString' }
-    auther { 'MyString' }
-    publisher { 'MyString' }
+    uuid { 'f3c93ae1-9ad9-4693-864c-44a502604eaa' }
+    title { 'サンプルタイトル' }
+    auther { 'サンプル著者' }
+    publisher { 'サンプル出版社' }
     published_on { '2022-04-01' }
-    series { 'MyString' }
-    page_size { 1 }
+    series { 'サンプルシリーズ' }
+    page_size { 100 }
   end
 end

--- a/spec/factories/books.rb
+++ b/spec/factories/books.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :book do
+    uuid { "MyString" }
+    title { "MyString" }
+    auther { "MyString" }
+    publisher { "MyString" }
+    published_on { "2022-04-01" }
+    series { "MyString" }
+    page_size { 1 }
+  end
+end

--- a/spec/models/book_spec.rb
+++ b/spec/models/book_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Book, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/book_spec.rb
+++ b/spec/models/book_spec.rb
@@ -19,13 +19,13 @@ RSpec.describe 'Bookモデルのテスト', type: :model do
         expect(book.errors[:title]).to include('を入力してください')
       end
 
-      it '30文字以上は通らないこと' do # TODO: Faker::Lorem.characters(number:31) gem faker を使っても良いか相談。
-        book.title = 'abcdefghijklmnopqrstuvwxyzabcde' # 31文字
+      it '31文字以上は通らないこと' do # TODO: Faker::Lorem.characters(number:31) gem faker を使っても良いか相談。
+        book.title = Faker::Lorem.characters(number:31)
         expect(book.valid?).to eq false
       end
 
       it '30文字以下は通ること' do
-        book.title = 'abcdefghijklmnopqrstuvwxyzabcd' # 30文字
+        book.title = Faker::Lorem.characters(number:30)
         expect(book.valid?).to eq true
       end
     end

--- a/spec/models/book_spec.rb
+++ b/spec/models/book_spec.rb
@@ -1,5 +1,49 @@
 require 'rails_helper'
 
-RSpec.describe Book, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+RSpec.describe 'Bookモデルのテスト', type: :model do
+  describe 'バリデーションのテスト' do
+    subject do
+      book
+    end
+
+    let!(:book) { create(:book) }
+
+    it 'バリデーションが通ること' do
+      expect(subject).to be_valid
+    end
+
+    context 'titleカラム' do
+      it '空欄でないこと' do
+        book.title = ''
+        expect(book).to be_invalid
+        expect(book.errors[:title]).to include('を入力してください')
+      end
+
+      it '30文字以上は通らないこと' do # TODO: Faker::Lorem.characters(number:31) gem faker を使っても良いか相談。
+        book.title = 'abcdefghijklmnopqrstuvwxyzabcde' # 31文字
+        expect(book.valid?).to eq false
+      end
+
+      it '30文字以下は通ること' do
+        book.title = 'abcdefghijklmnopqrstuvwxyzabcd' # 30文字
+        expect(book.valid?).to eq true
+      end
+    end
+
+    context 'page_sizeカラム' do
+      it '空欄でないこと' do
+        book.page_size = ''
+        expect(book).to be_invalid
+        expect(book.errors[:page_size]).to include('を入力してください')
+      end
+    end
+
+    context 'uuidカラム' do
+      it '空欄でないこと' do
+        book.uuid = ''
+        expect(book).to be_invalid
+        expect(book.errors[:uuid]).to include('を入力してください')
+      end
+    end
+  end
 end

--- a/spec/models/book_spec.rb
+++ b/spec/models/book_spec.rb
@@ -20,12 +20,12 @@ RSpec.describe 'Bookモデルのテスト', type: :model do
       end
 
       it '31文字以上は通らないこと' do # TODO: Faker::Lorem.characters(number:31) gem faker を使っても良いか相談。
-        book.title = Faker::Lorem.characters(number:31)
+        book.title = Faker::Lorem.characters(number: 31)
         expect(book.valid?).to eq false
       end
 
       it '30文字以下は通ること' do
-        book.title = Faker::Lorem.characters(number:30)
+        book.title = Faker::Lorem.characters(number: 30)
         expect(book.valid?).to eq true
       end
     end


### PR DESCRIPTION
### やったこと
- book テーブルの作成。
- uuid をプライマリーキーにセット
- ER図に沿ったテーブルとバリデーションをセット。
- model_spec を作成。

### やらなかったこと
- 特になし。

### 確認したこと
- [x] ER図に沿ったテーブル設計になっていること。
- [x] バリデーションのテストができていること。
- [x] URL設計図に沿ったルーティングが設定されていること。

### 確認画像

- 設計資料に沿ったルーティング
<img width="1418" alt="スクリーンショット 2022-04-01 午後9 41 03" src="https://user-images.githubusercontent.com/36902599/161264191-0ba19dd3-0132-4c96-b50f-daa265d5c0ad.png">
<img width="823" alt="スクリーンショット 2022-04-01 午後10 33 53" src="https://user-images.githubusercontent.com/36902599/161264254-28d34812-946b-4ee3-bc1d-1a7a4b9f1c74.png">


### その他
特になし。
