### PR TITLE
step4-1[books]ElasticSearchを使ってindexを作る

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,9 +70,9 @@ gem 'kaminari'
 
 # 全文検索エンジン
 gem 'bonsai-elasticsearch-rails', '~> 7'
+gem 'elasticsearch', '7.13'
 gem 'elasticsearch-model', '~> 7'
 gem 'elasticsearch-rails', '~> 7'
-gem 'elasticsearch', '7.13'
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"

--- a/Gemfile
+++ b/Gemfile
@@ -68,6 +68,12 @@ gem 'cancancan'
 # ページネーション
 gem 'kaminari'
 
+# 全文検索エンジン
+gem 'bonsai-elasticsearch-rails', '~> 7'
+gem 'elasticsearch-model', '~> 7'
+gem 'elasticsearch-rails', '~> 7'
+gem 'elasticsearch', '7.13'
+
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,6 +75,9 @@ GEM
     ast (2.4.2)
     bcrypt (3.1.16)
     bindex (0.8.1)
+    bonsai-elasticsearch-rails (7.0.1)
+      elasticsearch-model (< 8)
+      elasticsearch-rails (< 8)
     bootsnap (1.10.3)
       msgpack (~> 1.2)
     brakeman (5.2.1)
@@ -127,6 +130,19 @@ GEM
     dotenv-rails (2.7.6)
       dotenv (= 2.7.6)
       railties (>= 3.2)
+    elasticsearch (7.13.0)
+      elasticsearch-api (= 7.13.0)
+      elasticsearch-transport (= 7.13.0)
+    elasticsearch-api (7.13.0)
+      multi_json
+    elasticsearch-model (7.2.1)
+      activesupport (> 3)
+      elasticsearch (~> 7)
+      hashie
+    elasticsearch-rails (7.2.1)
+    elasticsearch-transport (7.13.0)
+      faraday (~> 1)
+      multi_json
     erubi (1.10.0)
     factory_bot (6.2.0)
       activesupport (>= 5.0.0)
@@ -135,9 +151,33 @@ GEM
       railties (>= 5.0.0)
     faker (2.20.0)
       i18n (>= 1.8.11, < 2)
+    faraday (1.10.0)
+      faraday-em_http (~> 1.0)
+      faraday-em_synchrony (~> 1.0)
+      faraday-excon (~> 1.1)
+      faraday-httpclient (~> 1.0)
+      faraday-multipart (~> 1.0)
+      faraday-net_http (~> 1.0)
+      faraday-net_http_persistent (~> 1.0)
+      faraday-patron (~> 1.0)
+      faraday-rack (~> 1.0)
+      faraday-retry (~> 1.0)
+      ruby2_keywords (>= 0.0.4)
+    faraday-em_http (1.0.0)
+    faraday-em_synchrony (1.0.0)
+    faraday-excon (1.1.0)
+    faraday-httpclient (1.0.1)
+    faraday-multipart (1.0.3)
+      multipart-post (>= 1.2, < 3)
+    faraday-net_http (1.0.1)
+    faraday-net_http_persistent (1.2.0)
+    faraday-patron (1.0.0)
+    faraday-rack (1.0.0)
+    faraday-retry (1.0.3)
     ffi (1.15.5)
     globalid (1.0.0)
       activesupport (>= 5.0)
+    hashie (5.0.0)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     io-console (0.5.11)
@@ -182,6 +222,8 @@ GEM
     mini_mime (1.1.2)
     minitest (5.15.0)
     msgpack (1.4.5)
+    multi_json (1.15.0)
+    multipart-post (2.1.1)
     mysql2 (0.5.3)
     nested_form (0.3.2)
     net-imap (0.2.3)
@@ -305,6 +347,7 @@ GEM
     ruby-graphviz (1.2.5)
       rexml
     ruby-progressbar (1.11.0)
+    ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     sassc (2.4.0)
       ffi (~> 1.9)
@@ -376,6 +419,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  bonsai-elasticsearch-rails (~> 7)
   bootsnap
   brakeman
   bullet
@@ -388,6 +432,9 @@ DEPENDENCIES
   devise-i18n
   devise-i18n-views
   dotenv-rails
+  elasticsearch (= 7.13)
+  elasticsearch-model (~> 7)
+  elasticsearch-rails (~> 7)
   factory_bot_rails
   faker
   jbuilder

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -1,4 +1,7 @@
+require 'elasticsearch/model'
+
 class Book < ApplicationRecord
+  include Books::Searchable
   before_create -> { self.uuid = SecureRandom.uuid }
   attribute :uuid, :string, default: -> { SecureRandom.uuid }
 

--- a/app/models/books/searchable.rb
+++ b/app/models/books/searchable.rb
@@ -35,7 +35,11 @@ module Books
       def create_index!
         client = __elasticsearch__.client
         # すでにindexを作成済みの場合は削除する
-        client.indices.delete index: self.index_name rescue nil
+        begin
+          client.indices.delete index: self.index_name
+        rescue StandardError
+          nil
+        end
         # indexを作成する
         client.indices.create(index: self.index_name,
           body: {
@@ -49,9 +53,9 @@ module Books
       Book.search({
         query: {
           multi_match: {
-            fields: %w( uuid title auther publisher published_on series page_size),
-            type: 'cross_fields',
-            query: query,
+            fields:   %w[uuid title auther publisher published_on series page_size],
+            type:     'cross_fields',
+            query:    query,
             operator: 'and'
           }
         }

--- a/app/models/books/searchable.rb
+++ b/app/models/books/searchable.rb
@@ -1,0 +1,61 @@
+module Books
+  require 'elasticsearch/model'
+
+  module Searchable
+    extend ActiveSupport::Concern
+
+    included do
+      include Elasticsearch::Model
+      include Elasticsearch::Model::Callbacks
+
+      # ①index名
+      index_name "es_rails7_#{Rails.env}"
+
+      # ②mapping情報
+      settings do
+        mappings dynamic: 'false' do
+          indexes :id,        type: 'integer'
+          indexes :title,     type: 'keyword'
+          indexes :auther,    type: 'keyword'
+          indexes :publisher, type: 'text'
+          indexes :series,    type: 'text'
+        end
+      end
+
+      # ③mappingの定義に合わせてindexするドキュメントの情報を生成する
+      def as_indexed_json(*)
+        attributes
+          .symbolize_keys
+          .slice(:id, :title, :auther, :publisher, :series)
+      end
+    end
+
+    class_methods do
+      # ④indexを作成するメソッド
+      def create_index!
+        client = __elasticsearch__.client
+        # すでにindexを作成済みの場合は削除する
+        client.indices.delete index: self.index_name rescue nil
+        # indexを作成する
+        client.indices.create(index: self.index_name,
+          body: {
+            settings: self.settings.to_hash,
+            mappings: self.mappings.to_hash
+          })
+      end
+    end
+
+    def elastic_search(query)
+      Book.search({
+        query: {
+          multi_match: {
+            fields: %w( uuid title auther publisher published_on series page_size),
+            type: 'cross_fields',
+            query: query,
+            operator: 'and'
+          }
+        }
+      })
+    end
+  end
+end

--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -1,0 +1,16 @@
+if Rails.env.production?
+  Elasticsearch::Model.client =
+    Elasticsearch::Client.new(
+      url: ENV['BONSAI_URL']
+    )
+else
+  Elasticsearch::Model.client =
+    Elasticsearch::Client.new(
+      hosts: [
+        {
+          host: 'elasticsearch',
+          port: '9200'
+        }
+      ]
+    )
+end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       - 3000:3000
     depends_on:
       - db
+      - elasticsearch
 
   db:
     restart: always
@@ -30,7 +31,24 @@ services:
     volumes:
       - mysql-data:/var/lib/mysql
 
+  elasticsearch:
+    build: ./docker/elasticsearch
+    volumes:
+      - es-data:/usr/share/elasticsearch/data
+    environment:
+      - discovery.type=single-node
+      - cluster.name=docker-cluster
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    ports:
+      - "9200:9200"
+
 volumes:
   mysql-data:
   bundle:
   node_modules:
+  es-data:

--- a/docker/elasticsearch/Dockerfile
+++ b/docker/elasticsearch/Dockerfile
@@ -1,0 +1,4 @@
+FROM docker.elastic.co/elasticsearch/elasticsearch:7.10.2
+
+# 日本語全文検索pulgin
+RUN elasticsearch-plugin install analysis-kuromoji

--- a/spec/models/books/searchable_spec.rb
+++ b/spec/models/books/searchable_spec.rb
@@ -1,0 +1,59 @@
+require 'rails_helper'
+
+RSpec.describe 'Elasticsearchの全文検索テスト', elasticsearch: true do
+
+  describe '.Elasticsearchの全文検索テスト' do
+    describe '検索にマッチする図書データの検索' do
+      let!(:book_1) do
+        create(:book, uuid: "27b84b0d-0ce5-4b23-81f3-736f808e89c2", title: '河童', auther: "菅原翔", publisher: "勉誠出版", published_on: '2022-04-01', series: "歴史", page_size: 421)
+      end
+      let!(:book_2) do
+        create(:book, uuid: "2549dc87-5b13-494c-abd0-ec0f7a872f44", title: '阿部一族', auther: "田中優", publisher: "第一法規", published_on: '2022-04-02', series: "歴史・時代小説", page_size: 841)
+      end
+      let!(:book_3) do
+        create(:book, uuid: "247c6698-0bc1-41d4-a969-d4bc5c713b7b", title: '或恋愛小説', auther: '田村優斗', publisher: "金剛出版", published_on: '2022-04-03', series: "イラスト・デザイン", page_size: 831)
+      end
+
+      before :each do
+        # 作成したデータをelasticsearchに登録する
+        Book.__elasticsearch__.import(refresh: true)
+      end
+
+      def search_book_uuid
+        Book.new.elastic_search(query).records.pluck(:uuid)
+      end
+
+      context '検索ワードがタイトルにマッチする場合' do
+        let(:query) { '河童' }
+
+        it '検索ワードにマッチする図書データを取得する' do
+          expect(search_book_uuid).to eq [book_1.uuid]
+        end
+      end
+
+      context '検索ワードが著者にマッチする場合' do
+        let(:query) { '田村優斗' }
+
+        it '検索ワードにマッチする図書データを取得する' do
+          expect(search_book_uuid).to eq [book_3.uuid]
+        end
+      end
+
+      context '検索ワードがシリーズにマッチする場合' do
+        let(:query) { 'イラスト・デザイン' }
+
+        it '検索ワードにマッチする図書データを取得する' do
+          expect(search_book_uuid).to eq [book_3.uuid]
+        end
+      end
+
+      context '検索ワードが出版社にマッチする場合' do
+        let(:query) { '第一法規' }
+
+        it '検索ワードにマッチする図書データを取得する' do
+          expect(search_book_uuid).to eq [book_2.uuid]
+        end
+      end
+    end
+  end
+end

--- a/spec/models/books/searchable_spec.rb
+++ b/spec/models/books/searchable_spec.rb
@@ -1,17 +1,16 @@
 require 'rails_helper'
 
-RSpec.describe 'Elasticsearchの全文検索テスト', elasticsearch: true do
-
+RSpec.describe 'Searchable', elasticsearch: true do
   describe '.Elasticsearchの全文検索テスト' do
     describe '検索にマッチする図書データの検索' do
-      let!(:book_1) do
-        create(:book, uuid: "27b84b0d-0ce5-4b23-81f3-736f808e89c2", title: '河童', auther: "菅原翔", publisher: "勉誠出版", published_on: '2022-04-01', series: "歴史", page_size: 421)
+      let!(:book1) do
+        create(:book, uuid: '27b84b0d-0ce5-4b23-81f3-736f808e89c2', title: '河童', auther: '菅原翔', publisher: '勉誠出版', published_on: '2022-04-01', series: '歴史', page_size: 421)
       end
-      let!(:book_2) do
-        create(:book, uuid: "2549dc87-5b13-494c-abd0-ec0f7a872f44", title: '阿部一族', auther: "田中優", publisher: "第一法規", published_on: '2022-04-02', series: "歴史・時代小説", page_size: 841)
+      let!(:book2) do
+        create(:book, uuid: '2549dc87-5b13-494c-abd0-ec0f7a872f44', title: '阿部一族', auther: '田中優', publisher: '第一法規', published_on: '2022-04-02', series: '歴史・時代小説', page_size: 841)
       end
-      let!(:book_3) do
-        create(:book, uuid: "247c6698-0bc1-41d4-a969-d4bc5c713b7b", title: '或恋愛小説', auther: '田村優斗', publisher: "金剛出版", published_on: '2022-04-03', series: "イラスト・デザイン", page_size: 831)
+      let!(:book3) do
+        create(:book, uuid: '247c6698-0bc1-41d4-a969-d4bc5c713b7b', title: '或恋愛小説', auther: '田村優斗', publisher: '金剛出版', published_on: '2022-04-03', series: 'イラスト・デザイン', page_size: 831)
       end
 
       before :each do
@@ -27,7 +26,7 @@ RSpec.describe 'Elasticsearchの全文検索テスト', elasticsearch: true do
         let(:query) { '河童' }
 
         it '検索ワードにマッチする図書データを取得する' do
-          expect(search_book_uuid).to eq [book_1.uuid]
+          expect(search_book_uuid).to eq [book1.uuid]
         end
       end
 
@@ -35,7 +34,7 @@ RSpec.describe 'Elasticsearchの全文検索テスト', elasticsearch: true do
         let(:query) { '田村優斗' }
 
         it '検索ワードにマッチする図書データを取得する' do
-          expect(search_book_uuid).to eq [book_3.uuid]
+          expect(search_book_uuid).to eq [book3.uuid]
         end
       end
 
@@ -43,7 +42,7 @@ RSpec.describe 'Elasticsearchの全文検索テスト', elasticsearch: true do
         let(:query) { 'イラスト・デザイン' }
 
         it '検索ワードにマッチする図書データを取得する' do
-          expect(search_book_uuid).to eq [book_3.uuid]
+          expect(search_book_uuid).to eq [book3.uuid]
         end
       end
 
@@ -51,7 +50,34 @@ RSpec.describe 'Elasticsearchの全文検索テスト', elasticsearch: true do
         let(:query) { '第一法規' }
 
         it '検索ワードにマッチする図書データを取得する' do
-          expect(search_book_uuid).to eq [book_2.uuid]
+          expect(search_book_uuid).to eq [book2.uuid]
+        end
+      end
+    end
+
+    describe '更新後の検索にマッチする図書データの検索' do
+      let!(:book1) do
+        create(:book, uuid: '27b84b0d-0ce5-4b23-81f3-736f808e89c2', title: '河童', auther: '菅原翔', publisher: '勉誠出版', published_on: '2022-04-01', series: '歴史', page_size: 421)
+      end
+
+      before(:each) do
+        Book.__elasticsearch__.import(refresh: true)
+      end
+
+      def search_book_uuid
+        Book.new.elastic_search(query).records.pluck(:uuid)
+      end
+
+      context 'データ更新後の検索にマッチする図書データの検索' do
+        before(:each) do
+          book1.update(title: '河童2')
+          Book.new.__elasticsearch__.update_document(refresh: true)
+        end
+
+        let(:query) { '河童2' }
+
+        it '検索ワードにマッチする図書データを取得する' do
+          expect(search_book_uuid).to eq [book1.uuid]
         end
       end
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -88,6 +88,13 @@ RSpec.configure do |config|
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.include Devise::Test::ControllerHelpers, type: :view
   config.include Devise::Test::IntegrationHelpers, type: :system
+
+  # Elasticsearchのindex作成
+  config.before :each do |example|
+    if example.metadata[:elasticsearch]
+      Book.create_index!
+    end
+  end
 end
 
 def login_manager


### PR DESCRIPTION
### やったこと
- ElasticSearch関連のgemを追加。
- Indexを作成。
- コンソール上で全文検索ができる。
- indexのデータが更新できること。

### やらなかったこと
- 特になし。

### 確認したこと
- [x] テストデータをコンソール上で全文検索できること。
- [x] 更新したデータを全文検索できること。

### 確認画像
コンソールで全文検索した動画です。
<img width="1045" alt="スクリーンショット 2022-04-03 午後8 25 50" src="https://user-images.githubusercontent.com/36902599/161425111-ce144f02-ac3f-42e8-8679-025133c24fce.png">

Elasticserachで更新データを反映させた画像です。タイトルを更新しています。
<img width="1123" alt="スクリーンショット 2022-04-03 午後9 23 16" src="https://user-images.githubusercontent.com/36902599/161425506-466daca6-88de-4c85-a237-f5f7eeb36ef1.png">


### その他
特になし。
